### PR TITLE
iw list -> iwlist

### DIFF
--- a/Setup RaspberryPi as hotspot.org
+++ b/Setup RaspberryPi as hotspot.org
@@ -147,7 +147,7 @@ I have tested the next steps with the usb wi-fi dongle DWA-131.
 
 At this point everything should work, but only if your usb wi-fi dongle uses the "nl80211" driver. To check out, use the command:
 
-: iw list
+: iwlist
 
 If the output is =nl80211 not found=, then you need to use the "rtl871xdrv" driver.
 

--- a/Setup RaspberryPi as hotspot.org
+++ b/Setup RaspberryPi as hotspot.org
@@ -149,6 +149,8 @@ At this point everything should work, but only if your usb wi-fi dongle uses the
 
 : iwlist
 
+(Note: on =iwlist= see: http://manpages.ubuntu.com/manpages/karmic/man8/iwlist.8.html)
+
 If the output is =nl80211 not found=, then you need to use the "rtl871xdrv" driver.
 
 Open the file =/etc/hostapd/hostapd.conf= and comment out the line about the "nl80211" driver. Then uncomment the line about the "rtl871xdrv" driver.


### PR DESCRIPTION
command "iw list" may be a typo.  Should it not be: iwlist? 

I added a link to Ubuntu doc on this. 
